### PR TITLE
Add city search to weather endpoint

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -34,9 +34,32 @@ app.MapGet("/weatherforecast", () =>
 .WithName("GetWeatherForecast")
 .WithOpenApi();
 
+// New endpoint to search weather data by city
+app.MapGet("/weatherforecast/city", (string city) =>
+{
+    var forecastByCity = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecastByCity
+        (
+            city,
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecastByCity;
+})
+.WithName("GetWeatherForecastByCity")
+.WithOpenApi();
+
 app.Run();
 
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+// New record to include city information in weather forecast
+internal record WeatherForecastByCity(string City, DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }


### PR DESCRIPTION
Related to #1

Adds a new endpoint to search weather data by city and introduces a new record to include city information in weather forecasts.
- Implements a new endpoint `/weatherforecast/city` that accepts a `city` query parameter, allowing users to search weather data by city.
- Introduces a new record `WeatherForecastByCity` that includes a `City` field along with the existing weather forecast fields, enabling the return of weather data with city information.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/adiazcan/dotnet-codespaces/issues/1?shareId=51df2e78-8eee-416e-8bc3-c6fb35c28070).